### PR TITLE
RF69 Examples for the T3.x and T4.x with readme

### DIFF
--- a/examples/Teensy/README.md
+++ b/examples/Teensy/README.md
@@ -1,0 +1,5 @@
+Teensy 3.x and T4.x Specific Examples for Certain Radios
+
+According to libraries for the RF69, RF95, RF24, RF22, MRF89 and the CC110 radios you have to pass interruptnumber-to-interruptpin mapping as opposed to just the pin number.  This is accoplished by passing digitalPinToInterrupt(n) where "n" can be 0, 1, or 2 for the allowable interrupt pins.
+
+As a sample this was done for RF69 examples and tested on a T3.2 and a T4.

--- a/examples/Teensy/rf69_client/rf69_client.ino
+++ b/examples/Teensy/rf69_client/rf69_client.ino
@@ -1,0 +1,96 @@
+// rf69_client.pde
+// -*- mode: C++ -*-
+// Example sketch showing how to create a simple messageing client
+// with the RH_RF69 class. RH_RF69 class does not provide for addressing or
+// reliability, so you should only use RH_RF69  if you do not need the higher
+// level messaging abilities.
+// It is designed to work with the other example rf69_server.
+// Demonstrates the use of AES encryption, setting the frequency and modem 
+// configuration
+// Tested on Moteino with RFM69 http://lowpowerlab.com/moteino/
+// Tested on miniWireless with RFM69 www.anarduino.com/miniwireless
+// Tested on Teensy 3.1 with RF69 on PJRC breakout board
+
+#include <SPI.h>
+#include <RH_RF69.h>
+
+//For Teensy 3.x and T4.x the following format is required to operate correctly
+//This is a limitation of the RadioHead radio drivers
+#define RFM69_RST     3
+#define RFM69_CS      10
+#define RFM69_INT     digitalPinToInterrupt(2)
+
+// Singleton instance of the radio driver
+RH_RF69 rf69(RFM69_CS,RFM69_INT);
+//----- END TEENSY CONFIG
+
+//RH_RF69 rf69(15, 16); // For RF69 on PJRC breakout board with Teensy 3.1
+
+void setup() 
+{
+  Serial.begin(9600);
+  
+  //For Teensy 3.x and T4.x the following format is required to operate correctly
+  //pinMode(LED, OUTPUT);     
+  pinMode(RFM69_RST, OUTPUT);
+  digitalWrite(RFM69_RST, LOW);
+
+  Serial.println("Teensy RFM69 Client!");
+  Serial.println();
+
+  // manual reset
+  digitalWrite(RFM69_RST, HIGH);
+  delay(10);
+  digitalWrite(RFM69_RST, LOW);
+  delay(10);
+//----- END TEENSY CONFIG
+
+  if (!rf69.init())
+    Serial.println("init failed");
+  // Defaults after init are 434.0MHz, modulation GFSK_Rb250Fd250, +13dbM
+  // No encryption
+  if (!rf69.setFrequency(433.0))
+    Serial.println("setFrequency failed");
+
+  // If you are using a high power RF69, you *must* set a Tx power in the
+  // range 14 to 20 like this:
+   rf69.setTxPower(14);
+
+  // The encryption key has to be the same as the one in the server
+  uint8_t key[] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+                    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+  rf69.setEncryptionKey(key);
+}
+
+
+void loop()
+{
+  Serial.println("Sending to rf69_server");
+  // Send a message to rf69_server
+  uint8_t data[] = "Hello World!";
+  rf69.send(data, sizeof(data));
+  
+  rf69.waitPacketSent();
+  // Now wait for a reply
+  uint8_t buf[RH_RF69_MAX_MESSAGE_LEN];
+  uint8_t len = sizeof(buf);
+
+  if (rf69.waitAvailableTimeout(500))
+  { 
+    // Should be a reply message for us now   
+    if (rf69.recv(buf, &len))
+    {
+      Serial.print("got reply: ");
+      Serial.println((char*)buf);
+    }
+    else
+    {
+      Serial.println("recv failed");
+    }
+  }
+  else
+  {
+    Serial.println("No reply, is rf69_server running?");
+  }
+  delay(400);
+}

--- a/examples/Teensy/rf69_reliable_datagram_client/rf69_reliable_datagram_client.ino
+++ b/examples/Teensy/rf69_reliable_datagram_client/rf69_reliable_datagram_client.ino
@@ -1,0 +1,90 @@
+// rf69_reliable_datagram_client.pde
+// -*- mode: C++ -*-
+// Example sketch showing how to create a simple addressed, reliable messaging client
+// with the RHReliableDatagram class, using the RH_RF69 driver to control a RF69 radio.
+// It is designed to work with the other example rf69_reliable_datagram_server
+// Tested on Moteino with RFM69 http://lowpowerlab.com/moteino/
+// Tested on miniWireless with RFM69 www.anarduino.com/miniwireless
+// Tested on Teensy 3.1 with RF69 on PJRC breakout board
+
+#include <RHReliableDatagram.h>
+#include <RH_RF69.h>
+#include <SPI.h>
+
+#define CLIENT_ADDRESS 1
+#define SERVER_ADDRESS 2
+
+//For Teensy 3.x and T4.x the following format is required to operate correctly
+//This is a limitation of the RadioHead radio drivers
+#define RFM69_RST     3   // "A"
+#define RFM69_CS      10  // "B"
+#define RFM69_INT     digitalPinToInterrupt(2)
+
+// Singleton instance of the radio driver
+RH_RF69 driver(RFM69_CS,RFM69_INT);
+//----- END TEENSY CONFIG
+
+//RH_RF69 driver(15, 16); // For RF69 on PJRC breakout board with Teensy 3.1
+//RH_RF69 rf69(4, 2); // For MoteinoMEGA https://lowpowerlab.com/shop/moteinomega
+
+// Class to manage message delivery and receipt, using the driver declared above
+RHReliableDatagram manager(driver, CLIENT_ADDRESS);
+
+void setup() 
+{
+  Serial.begin(9600);
+  
+  //For Teensy 3.x and T4.x the following format is required to operate correctly
+  //pinMode(LED, OUTPUT);     
+  pinMode(RFM69_RST, OUTPUT);
+  digitalWrite(RFM69_RST, LOW);
+
+  Serial.println("Teensy RFM69!");
+  Serial.println();
+
+  // manual reset - added for Teensy
+  digitalWrite(RFM69_RST, HIGH);
+  delay(10);
+  digitalWrite(RFM69_RST, LOW);
+  delay(10);
+  //----- END TEENSY CONFIG
+
+  if (!manager.init())
+    Serial.println("init failed");
+  // Defaults after init are 434.0MHz, modulation GFSK_Rb250Fd250, +13dbM
+
+  // If you are using a high power RF69, you *must* set a Tx power in the
+  // range 14 to 20 like this:
+   driver.setTxPower(14);
+}
+
+uint8_t data[] = "Hello World!";
+// Dont put this on the stack:
+uint8_t buf[RH_RF69_MAX_MESSAGE_LEN];
+
+void loop()
+{
+  Serial.println("Sending to rf69_reliable_datagram_server");
+    
+  // Send a message to manager_server
+  if (manager.sendtoWait(data, sizeof(data), SERVER_ADDRESS))
+  {
+    // Now wait for a reply from the server
+    uint8_t len = sizeof(buf);
+    uint8_t from;   
+    if (manager.recvfromAckTimeout(buf, &len, 2000, &from))
+    {
+      Serial.print("got reply from : 0x");
+      Serial.print(from, HEX);
+      Serial.print(": ");
+      Serial.println((char*)buf);
+    }
+    else
+    {
+      Serial.println("No reply, is rf69_reliable_datagram_server running?");
+    }
+  }
+  else
+    Serial.println("sendtoWait failed");
+  delay(500);
+}

--- a/examples/Teensy/rf69_reliable_datagram_server/rf69_reliable_datagram_server.ino
+++ b/examples/Teensy/rf69_reliable_datagram_server/rf69_reliable_datagram_server.ino
@@ -1,0 +1,84 @@
+// rf69_reliable_datagram_server.pde
+// -*- mode: C++ -*-
+// Example sketch showing how to create a simple addressed, reliable messaging server
+// with the RHReliableDatagram class, using the RH_RF69 driver to control a RF69 radio.
+// It is designed to work with the other example rf69_reliable_datagram_client
+// Tested on Moteino with RFM69 http://lowpowerlab.com/moteino/
+// Tested on miniWireless with RFM69 www.anarduino.com/miniwireless
+// Tested on Teensy 3.1 with RF69 on PJRC breakout board
+
+#include <RHReliableDatagram.h>
+#include <RH_RF69.h>
+#include <SPI.h>
+
+#define CLIENT_ADDRESS 1
+#define SERVER_ADDRESS 2
+
+//For Teensy 3.x and T4.x the following format is required to operate correctly
+//This is a limitation of the RadioHead radio drivers
+#define RFM69_RST     3 
+#define RFM69_CS      10
+#define RFM69_INT     digitalPinToInterrupt(2)
+
+// Singleton instance of the radio driver
+RH_RF69 driver(RFM69_CS,RFM69_INT);
+//----- END TEENSY CONFIG
+
+//RH_RF69 driver(15, 16); // For RF69 on PJRC breakout board with Teensy 3.1
+//RH_RF69 rf69(4, 2); // For MoteinoMEGA https://lowpowerlab.com/shop/moteinomega
+
+// Class to manage message delivery and receipt, using the driver declared above
+RHReliableDatagram manager(driver, SERVER_ADDRESS);
+
+void setup() 
+{
+  Serial.begin(9600);
+  
+  //For Teensy 3.x and T4.x the following format is required to operate correctly
+  //pinMode(LED, OUTPUT);     
+  pinMode(RFM69_RST, OUTPUT);
+  digitalWrite(RFM69_RST, LOW);
+
+  Serial.println("Teensy RFM69 datagram server example!");
+  Serial.println();
+
+  // manual reset
+  digitalWrite(RFM69_RST, HIGH);
+  delay(10);
+  digitalWrite(RFM69_RST, LOW);
+  delay(10);
+  //----- END TEENSY CONFIG
+
+  if (!manager.init())
+    Serial.println("init failed");
+  // Defaults after init are 434.0MHz, modulation GFSK_Rb250Fd250, +13dbM
+
+  // If you are using a high power RF69, you *must* set a Tx power in the
+  // range 14 to 20 like this:
+   driver.setTxPower(14);
+}
+
+uint8_t data[] = "And hello back to you";
+// Dont put this on the stack:
+uint8_t buf[RH_RF69_MAX_MESSAGE_LEN];
+
+void loop()
+{
+  if (manager.available())
+  {
+    // Wait for a message addressed to us from the client
+    uint8_t len = sizeof(buf);
+    uint8_t from;
+    if (manager.recvfromAck(buf, &len, &from))
+    {
+      Serial.print("got request from : 0x");
+      Serial.print(from, HEX);
+      Serial.print(": ");
+      Serial.println((char*)buf);
+
+      // Send a reply back to the originator client
+      if (!manager.sendtoWait(data, sizeof(data), from))
+        Serial.println("sendtoWait failed");
+    }
+  }
+}

--- a/examples/Teensy/rf69_rx_demo/rf69_rx_demo.ino
+++ b/examples/Teensy/rf69_rx_demo/rf69_rx_demo.ino
@@ -1,0 +1,118 @@
+// rf69 demo tx rx.pde
+// -*- mode: C++ -*-
+// Example sketch showing how to create a simple messageing client
+// with the RH_RF69 class. RH_RF69 class does not provide for addressing or
+// reliability, so you should only use RH_RF69  if you do not need the higher
+// level messaging abilities.
+// It is designed to work with the other example rf69_server.
+// Demonstrates the use of AES encryption, setting the frequency and modem 
+// configuration
+
+#include <SPI.h>
+#include <RH_RF69.h>
+
+/************ Radio Setup ***************/
+
+// Change to 434.0 or other frequency, must match RX's freq!
+#define RF69_FREQ 434.0
+
+//For Teensy 3.x and T4.x the following format is required to operate correctly
+//This is a limitation of the RadioHead radio drivers
+#define RFM69_RST     3
+#define RFM69_CS      10
+#define RFM69_INT     digitalPinToInterrupt(2)
+//----- END TEENSY CONFIG
+
+  #define LED           14
+
+// Singleton instance of the radio driver
+RH_RF69 rf69(RFM69_CS);
+
+int16_t packetnum = 0;  // packet counter, we increment per xmission
+
+void setup() 
+{
+  Serial.begin(115200);
+  delay(3000);
+  //while (!Serial) { delay(1); } // wait until serial console is open, remove if not tethered to computer
+
+  //For Teensy 3.x and T4.x the following format is required to operate correctly
+  pinMode(LED, OUTPUT);     
+  pinMode(RFM69_RST, OUTPUT);
+  digitalWrite(RFM69_RST, LOW);
+
+  Serial.println("Teensy RFM69 RX Test!");
+  Serial.println();
+
+  // manual reset
+  digitalWrite(RFM69_RST, HIGH);
+  delay(10);
+  digitalWrite(RFM69_RST, LOW);
+  delay(10);
+  //----- END TEENSY CONFIG
+
+  if (!rf69.init()) {
+    Serial.println("RFM69 radio init failed");
+    while (1);
+  }
+  Serial.println("RFM69 radio init OK!");
+  
+  // Defaults after init are 434.0MHz, modulation GFSK_Rb250Fd250, +13dbM (for low power module)
+  // No encryption
+  if (!rf69.setFrequency(RF69_FREQ)) {
+    Serial.println("setFrequency failed");
+  }
+
+  // If you are using a high power RF69 eg RFM69HW, you *must* set a Tx power with the
+  // ishighpowermodule flag set like this:
+  rf69.setTxPower(20);  // range from 14-20 for power, 2nd arg must be true for 69HCW
+
+  // The encryption key has to be the same as the one in the server
+  uint8_t key[] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+                    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+  rf69.setEncryptionKey(key);
+  
+  pinMode(LED, OUTPUT);
+
+  Serial.print("RFM69 radio @");  Serial.print((int)RF69_FREQ);  Serial.println(" MHz");
+}
+
+
+void loop() {
+ if (rf69.available()) {
+    // Should be a message for us now   
+    uint8_t buf[RH_RF69_MAX_MESSAGE_LEN];
+    uint8_t len = sizeof(buf);
+    if (rf69.recv(buf, &len)) {
+      if (!len) return;
+      buf[len] = 0;
+      Serial.print("Received [");
+      Serial.print(len);
+      Serial.print("]: ");
+      Serial.println((char*)buf);
+      Serial.print("RSSI: ");
+      Serial.println(rf69.lastRssi(), DEC);
+
+      if (strstr((char *)buf, "Hello World")) {
+        // Send a reply!
+        uint8_t data[] = "And hello back to you";
+        rf69.send(data, sizeof(data));
+        rf69.waitPacketSent();
+        Serial.println("Sent a reply");
+        Blink(LED, 40, 3); //blink LED 3 times, 40ms between blinks
+      }
+    } else {
+      Serial.println("Receive failed");
+    }
+  }
+}
+
+
+void Blink(byte PIN, byte DELAY_MS, byte loops) {
+  for (byte i=0; i<loops; i++)  {
+    digitalWrite(PIN,HIGH);
+    delay(DELAY_MS);
+    digitalWrite(PIN,LOW);
+    delay(DELAY_MS);
+  }
+}

--- a/examples/Teensy/rf69_server/rf69_server.ino
+++ b/examples/Teensy/rf69_server/rf69_server.ino
@@ -1,0 +1,101 @@
+// rf69_server.pde
+// -*- mode: C++ -*-
+// Example sketch showing how to create a simple messageing server
+// with the RH_RF69 class. RH_RF69 class does not provide for addressing or
+// reliability, so you should only use RH_RF69  if you do not need the higher
+// level messaging abilities.
+// It is designed to work with the other example rf69_client
+// Demonstrates the use of AES encryption, setting the frequency and modem
+// configuration.
+// Tested on Moteino with RFM69 http://lowpowerlab.com/moteino/
+// Tested on miniWireless with RFM69 www.anarduino.com/miniwireless
+// Tested on Teensy 3.1 with RF69 on PJRC breakout board
+
+#include <SPI.h>
+#include <RH_RF69.h>
+
+//For Teensy 3.x and T4.x the following format is required to operate correctly
+//This is a limitation of the RadioHead radio drivers
+#define RFM69_RST     3
+#define RFM69_CS      10
+#define RFM69_INT     digitalPinToInterrupt(2)  // only pins 0, 1, 2 allowed
+
+// Singleton instance of the radio driver
+RH_RF69 rf69(RFM69_CS,RFM69_INT);
+//----- END TEENSY CONFIG
+
+//RH_RF69 rf69(15, 16); // For RF69 on PJRC breakout board with Teensy 3.1
+//RH_RF69 rf69(4, 2); // For MoteinoMEGA https://lowpowerlab.com/shop/moteinomega
+
+void setup() 
+{
+  Serial.begin(9600);
+  
+  //For Teensy 3.x and T4.x the following format is required to operate correctly
+  //pinMode(LED, OUTPUT);     
+  pinMode(RFM69_RST, OUTPUT);
+  digitalWrite(RFM69_RST, LOW);
+
+  Serial.println("Teensy RFM69 Server Example!");
+  Serial.println();
+
+  // manual reset
+  digitalWrite(RFM69_RST, HIGH);
+  delay(10);
+  digitalWrite(RFM69_RST, LOW);
+  delay(10);
+  //----- END TEENSY CONFIG
+  
+  if (!rf69.init())
+    Serial.println("init failed");
+  // Defaults after init are 434.0MHz, modulation GFSK_Rb250Fd250, +13dbM
+  // No encryption
+  if (!rf69.setFrequency(433.0))
+    Serial.println("setFrequency failed");
+
+  // If you are using a high power RF69, you *must* set a Tx power in the
+  // range 14 to 20 like this:
+   rf69.setTxPower(14);
+
+ // The encryption key has to be the same as the one in the client
+  uint8_t key[] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+                    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+  rf69.setEncryptionKey(key);
+  
+#if 0
+  // For compat with RFM69 Struct_send
+  rf69.setModemConfig(RH_RF69::GFSK_Rb250Fd250);
+  rf69.setPreambleLength(3);
+  uint8_t syncwords[] = { 0x2d, 0x64 };
+  rf69.setSyncWords(syncwords, sizeof(syncwords));
+  rf69.setEncryptionKey((uint8_t*)"thisIsEncryptKey");
+#endif
+}
+
+void loop()
+{
+  if (rf69.available())
+  {
+    // Should be a message for us now   
+    uint8_t buf[RH_RF69_MAX_MESSAGE_LEN];
+    uint8_t len = sizeof(buf);
+    if (rf69.recv(buf, &len))
+    {
+//      RH_RF69::printBuffer("request: ", buf, len);
+      Serial.print("got request: ");
+      Serial.println((char*)buf);
+//      Serial.print("RSSI: ");
+//      Serial.println(rf69.lastRssi(), DEC);
+      
+      // Send a reply
+      uint8_t data[] = "And hello back to you";
+      rf69.send(data, sizeof(data));
+      rf69.waitPacketSent();
+      Serial.println("Sent a reply");
+    }
+    else
+    {
+      Serial.println("recv failed");
+    }
+  }
+}

--- a/examples/Teensy/rf69_tx_demo/rf69_tx_demo.ino
+++ b/examples/Teensy/rf69_tx_demo/rf69_tx_demo.ino
@@ -1,0 +1,114 @@
+// rf69 demo tx rx.pde
+// -*- mode: C++ -*-
+// Example sketch showing how to create a simple messageing client
+// with the RH_RF69 class. RH_RF69 class does not provide for addressing or
+// reliability, so you should only use RH_RF69  if you do not need the higher
+// level messaging abilities.
+// It is designed to work with the other example rf69_server.
+// Demonstrates the use of AES encryption, setting the frequency and modem 
+// configuration
+
+#include <SPI.h>
+#include <RH_RF69.h>
+
+/************ Radio Setup ***************/
+
+// Change to 434.0 or other frequency, must match RX's freq!
+#define RF69_FREQ 434.0
+
+//For Teensy 3.x and T4.x the following format is required to operate correctly
+//This is a limitation of the RadioHead radio drivers
+#define RFM69_RST     3
+#define RFM69_CS      10
+#define RFM69_INT     digitalPinToInterrupt(2)
+
+// Singleton instance of the radio driver
+RH_RF69 rf69(RFM69_CS,RFM69_INT);
+//----- END TEENSY CONFIG
+
+int16_t packetnum = 0;  // packet counter, we increment per xmission
+
+void setup() 
+{
+  Serial.begin(115200);
+  //while (!Serial) { delay(1); } // wait until serial console is open, remove if not tethered to computer
+
+  //For Teensy 3.x and T4.x the following format is required to operate correctly
+  //pinMode(LED, OUTPUT);     
+  pinMode(RFM69_RST, OUTPUT);
+  digitalWrite(RFM69_RST, LOW);
+
+  Serial.println("Feather RFM69 TX Test!");
+  Serial.println();
+
+  // manual reset
+  digitalWrite(RFM69_RST, HIGH);
+  delay(10);
+  digitalWrite(RFM69_RST, LOW);
+  delay(10);
+  //----- END TEENSY CONFIG
+
+  if (!rf69.init()) {
+    Serial.println("RFM69 radio init failed");
+    while (1);
+  }
+  Serial.println("RFM69 radio init OK!");
+  // Defaults after init are 434.0MHz, modulation GFSK_Rb250Fd250, +13dbM (for low power module)
+  // No encryption
+  if (!rf69.setFrequency(RF69_FREQ)) {
+    Serial.println("setFrequency failed");
+  }
+
+  // If you are using a high power RF69 eg RFM69HW, you *must* set a Tx power with the
+  // ishighpowermodule flag set like this:
+  rf69.setTxPower(20);  // range from 14-20 for power, 2nd arg must be true for 69HCW
+
+  // The encryption key has to be the same as the one in the server
+  uint8_t key[] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+                    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+  rf69.setEncryptionKey(key);
+  
+  //pinMode(LED, OUTPUT);
+
+  Serial.print("RFM69 radio @");  Serial.print((int)RF69_FREQ);  Serial.println(" MHz");
+}
+
+
+
+void loop() {
+  delay(1000);  // Wait 1 second between transmits, could also 'sleep' here!
+
+  char radiopacket[20] = "Hello World #";
+  itoa(packetnum++, radiopacket+13, 10);
+  Serial.print("Sending "); Serial.println(radiopacket);
+  
+  // Send a message!
+  rf69.send((uint8_t *)radiopacket, strlen(radiopacket));
+  rf69.waitPacketSent();
+
+  // Now wait for a reply
+  uint8_t buf[RH_RF69_MAX_MESSAGE_LEN];
+  uint8_t len = sizeof(buf);
+
+  if (rf69.waitAvailableTimeout(500))  { 
+    // Should be a reply message for us now   
+    if (rf69.recv(buf, &len)) {
+      Serial.print("Got a reply: ");
+      Serial.println((char*)buf);
+      //Blink(LED, 50, 3); //blink LED 3 times, 50ms between blinks
+    } else {
+      Serial.println("Receive failed");
+    }
+  } else {
+    Serial.println("No reply, is another RFM69 listening?");
+  }
+}
+
+void Blink(byte PIN, byte DELAY_MS, byte loops) {
+  for (byte i=0; i<loops; i++)  {
+    digitalWrite(PIN,HIGH);
+    delay(DELAY_MS);
+    digitalWrite(PIN,LOW);
+    delay(DELAY_MS);
+  }
+}


### PR DESCRIPTION
I updated the RF69 examples with what has to be done to make certain radios work with the T3.x and T4.x.  I also added a readme to identify the reason and the radios affected by the change.