### PR TITLE
Fix for use of ISRs with the RF69 driver on the ESP8266

### DIFF
--- a/RH_RF69.cpp
+++ b/RH_RF69.cpp
@@ -260,17 +260,31 @@ void RH_RF69::readFifo()
 // These are low level functions that call the interrupt handler for the correct
 // instance of RH_RF69.
 // 3 interrupts allows us to have 3 different devices
+// ESP8266 requires ISRs to be kept in IRAM using the ICACHE_FLASH_ATTR flag.
+// FIXME: ESP32 requires the IRAM_ATTR flag, same purpose, can't try this out as I don't have this controller so not adding it here.
+#ifdef ESP8266
+void ICACHE_FLASH_ATTR RH_RF69::isr0()
+#else
 void RH_RF69::isr0()
+#endif
 {
     if (_deviceForInterrupt[0])
 	_deviceForInterrupt[0]->handleInterrupt();
 }
+#ifdef ESP8266
+void ICACHE_FLASH_ATTR RH_RF69::isr1()
+#else
 void RH_RF69::isr1()
+#endif
 {
     if (_deviceForInterrupt[1])
 	_deviceForInterrupt[1]->handleInterrupt();
 }
+#ifdef ESP8266
+void ICACHE_FLASH_ATTR RH_RF69::isr2()
+#else
 void RH_RF69::isr2()
+#endif
 {
     if (_deviceForInterrupt[2])
 	_deviceForInterrupt[2]->handleInterrupt();


### PR DESCRIPTION
Fix for use of ISRs with the RF69 driver on the ESP8266 (note: the same change will have to be implemented for all other boards using interrupts).

Since ESP core 2.5.1 the interrupt handling has changed a bit: it is now enforced that ISRs are kept in IRAM rather than on Flash. This is something that should have been done this way all along, keeping the ISR on Flash can cause seemingly random crashes.

This is done by adding the ICACHE_FLASH_ATTR flag to the function in question. Here done, using #ifdef clauses as it is only for this specific processor.