### PR TITLE
Allow SPI1 and SPI2 on T4 boards.

### DIFF
--- a/RHHardwareSP12.cpp
+++ b/RHHardwareSP12.cpp
@@ -5,7 +5,7 @@
 // $Id: RHHardwareSPI2.cpp,v 1.16 2016/07/07 00:02:53 mikem Exp mikem $
 // This is a copy of the standard SPI node, that is hopefully setup to work on those processors
 // who have SPI2.  Currently I only have it setup for Teensy 3.5/3.6 
-#if defined(__arm__) && defined(TEENSYDUINO) && (defined(__MK64FX512__) || defined(__MK66FX1M0__) )
+#if defined(__arm__) && defined(TEENSYDUINO) && (defined(__MK64FX512__) || defined(__MK66FX1M0__) || defined(__IMXRT1052__)|| defined(__IMXRT1062__))
 
 #include <RHHardwareSPI2.h>
 

--- a/RHHardwareSP1I.cpp
+++ b/RHHardwareSP1I.cpp
@@ -5,7 +5,7 @@
 // $Id: RHHardwareSPI1.cpp,v 1.16 2016/07/07 00:02:53 mikem Exp mikem $
 // This is a copy of the standard SPI node, that is hopefully setup to work on those processors
 // who have SPI1.  Currently I only have it setup for Teensy 3.5/3.6 and LC
-#if defined(__arm__) && defined(TEENSYDUINO) && (defined(KINETISL) || defined(__MK64FX512__) || defined(__MK66FX1M0__) )
+#if defined(__arm__) && defined(TEENSYDUINO) && (defined(KINETISL) || defined(__MK64FX512__) || defined(__MK66FX1M0__) || defined(__IMXRT1052__)|| defined(__IMXRT1062__))
 
 #include <RHHardwareSPI1.h>
 

--- a/RHHardwareSPI1.h
+++ b/RHHardwareSPI1.h
@@ -6,7 +6,7 @@
 
 #ifndef RHHardwareSPI1_h
 #define RHHardwareSPI1_h
-#if defined(__arm__) && defined(TEENSYDUINO) && (defined(KINETISL) || defined(__MK64FX512__) || defined(__MK66FX1M0__) )
+#if defined(__arm__) && defined(TEENSYDUINO) && (defined(KINETISL) || defined(__MK64FX512__) || defined(__MK66FX1M0__) || defined(__IMXRT1052__)|| defined(__IMXRT1062__))
 
 #include <RHGenericSPI.h>
 
@@ -71,6 +71,6 @@ public:
 // Built in default instance
 extern RHHardwareSPI1 hardware_spi1;
 #else
-#error ("RadioHead SPI1 only supported on Teensy 3.5, 3.6 and LC")
+#error ("RadioHead SPI1 only supported on Teensy 3.5, 3.6, 4 and LC")
 #endif
 #endif

--- a/RHHardwareSPI2.h
+++ b/RHHardwareSPI2.h
@@ -6,7 +6,7 @@
 
 #ifndef RHHardwareSPI2_h
 #define RHHardwareSPI2_h
-#if defined(__arm__) && defined(TEENSYDUINO) && (defined(__MK64FX512__) || defined(__MK66FX1M0__) )
+#if defined(__arm__) && defined(TEENSYDUINO) && (defined(__MK64FX512__) || defined(__MK66FX1M0__) || defined(__IMXRT1052__)|| defined(__IMXRT1062__))
 
 #include <RHGenericSPI.h>
 
@@ -71,6 +71,6 @@ public:
 // Built in default instance
 extern RHHardwareSPI2 hardware_spi2;
 #else
-#error ("RadioHead SPI2 only supported on Teensy 3.5, 3.6")
+#error ("RadioHead SPI1 only supported on Teensy 3.5, 3.6, 4 and LC")
 #endif
 #endif


### PR DESCRIPTION
Just needed to change the #if defined...
directives to allow SPI1 and SPI2 to be used on T4

And changed error message on the #else case